### PR TITLE
fix(docker): fix compose reference to DUMB project

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - /home/username/docker/DMB/cli_debrid:/cli_debrid/data        ## Location for cli_debrid data
       - /home/username/docker/DMB/phalanx_db:/phalanx_db/data        ## Location for phalanx_db data
       - /home/username/docker/DMB/decypharr:/decypharr               ## Location for decypharr data
-      - /home/username/docker/DUMB/mnt/debrid:/mnt/debrid:rshared    ## Location for all symlinks and rclone mounts     
+      - /home/username/docker/DMB/mnt/debrid:/mnt/debrid:rshared     ## Location for all symlinks and rclone mounts     
     environment:
       - TZ=
       - PUID=


### PR DESCRIPTION
Debrid shared path appears to have leaked over from [I-am-PUID-0/DUMB](https://github.com/I-am-PUID-0/DUMB) project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the host path in the volume mapping for the DMB service, ensuring the debrid mount attaches correctly and services start/mount as expected.
  * No changes to mount options or other volumes; security-related settings remain unchanged.

* **Chores**
  * Added a missing end-of-file newline to the configuration for consistency; no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->